### PR TITLE
Update the hmPython3 version badge in README.md to be dynamic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hmPython3
 
-![hmPython3 v3.0.3](https://img.shields.io/badge/hmPython3-v3.0.3-6479ff.svg)
+![hmPython3](https://img.shields.io/github/v/release/komiyamma/hm_python3?color=6479ff&label=hmPython3)
 [![Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg?style=flat)](LICENSE)
 ![Hidemaru 8.73](https://img.shields.io/badge/Hidemaru-v8.73-6479ff.svg)
 ![Python 3.13.7](https://img.shields.io/badge/Python-v3.13.7-6479ff.svg?logo=python&logoColor=white)


### PR DESCRIPTION
The badge now points to the latest release on GitHub using Shields.io, ensuring it's always up-to-date. The label and color are preserved from the original badge.